### PR TITLE
Implement key hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Note that at the time, gecaso only supports versions of python that are >=3.5
 ##### Gecaso was created to be a simple solution that can be easily expanded to cover any needs of its users. Below is everything there is to know about using Gecaso.
 
 #### 1) "gecaso.cached" function
-This function is a wrapper that helps to set up cache for any synchronus or asynchronous function. It takes single positional argument, which must be an instance of class that is inherited from **BaseStorage**. It can also optionally be provided with a keyword argument **loop** which must be an instance of an event loop. Any keyword arguments provided besides **loop** will be passed to the **set** method of storage instance whenever it is being called.
+This function is a wrapper that helps to set up cache for any synchronus or asynchronous function. It takes single positional argument, which must be an instance of class that is inherited from **BaseStorage**. It can also optionally be provided with a keyword argument **loop** which must be an instance of an event loop. Has two keyword arguments: **\_loop** (event loop used by wrapper) and **\_hash_key** (default is "True"; if true, key will have fixed size of 65 symbols). Any additional keyword arguments provided will be passed to every specified storage with every **set** call.
 
 #### 2) "gecaso.BaseStorage" class
 Any storage provided to "cached" function should be inherited from this class. Base storage has 6 methods.

--- a/gecaso/cache.py
+++ b/gecaso/cache.py
@@ -29,7 +29,6 @@ def _cached(cache_storage, loop, hash_key, **params):
 
         async def wrapped_function(*args, **kwargs):
             key = make_key(function, *args, **kwargs)
-            print(key)
             try:
                 result = await cache_storage.get(key)
             except KeyError:

--- a/gecaso/cache.py
+++ b/gecaso/cache.py
@@ -4,7 +4,7 @@ from . import utils
 from . import storage
 
 
-def cached(cache_storage, loop=None, **params):
+def cached(cache_storage, _loop=None, _hash_key=True, **params):
     """ Wraps function to cache its value in cache_storage.
 
     Positional arguments:
@@ -14,18 +14,21 @@ def cached(cache_storage, loop=None, **params):
     loop -- instance of event loop. asyncio.get_event_loop called otherwise
     **params -- passed to cache_storage.set each time its called
     """
-    loop = loop or asyncio.get_event_loop()
+    loop = _loop or asyncio.get_event_loop()
     if not isinstance(cache_storage, storage.BaseStorage):
         raise ValueError('Provided storage is not subclass of base storage')
-    return _cached(cache_storage, loop, **params)
+    return _cached(cache_storage, loop, _hash_key, **params)
 
 
-def _cached(cache_storage, loop, **params):
+def _cached(cache_storage, loop, hash_key, **params):
+    make_key = utils.hash_key if hash_key else utils.make_key
+
     def wrapper(function):
         current_calls = dict()
 
         async def wrapped_function(*args, **kwargs):
-            key = utils.make_key(function, *args, **kwargs)
+            key = make_key(function, *args, **kwargs)
+            print(key)
             try:
                 result = await cache_storage.get(key)
             except KeyError:

--- a/gecaso/cache.py
+++ b/gecaso/cache.py
@@ -11,7 +11,8 @@ def cached(cache_storage, _loop=None, _hash_key=True, **params):
     cache_storage -- subclass of gecaso.BaseStorage used to store cached data
 
     Keyword arguments:
-    loop -- instance of event loop. asyncio.get_event_loop called otherwise
+    _loop -- instance of event loop. asyncio.get_event_loop called otherwise
+    _hash_key -- if True, any generated key will be a cache of fixed size
     **params -- passed to cache_storage.set each time its called
     """
     loop = _loop or asyncio.get_event_loop()

--- a/gecaso/utils.py
+++ b/gecaso/utils.py
@@ -1,5 +1,6 @@
 import pickle
 import inspect
+import hashlib
 import functools
 
 
@@ -11,6 +12,13 @@ class Namespace:
 def make_key(function, *args, **kwargs):
     name_and_args = (function.__qualname__,) + tuple(a for a in args)
     return functools._make_key(name_and_args, kwargs, False)
+
+
+def hash_key(function, *args, **kwargs):
+    function_hash = hashlib.md5(bytes(function.__qualname__, 'utf-8'))
+    params = str(functools._make_key(args, kwargs, False))
+    params_hash = hashlib.md5(bytes(params, 'utf-8'))
+    return '{}_{}'.format(function_hash.hexdigest(), params_hash.hexdigest())
 
 
 def wrap(function, wrapped_function):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 
-version = '0.3.1'
+version = '0.4.0'
 url = 'https://github.com/festinuz/gecaso'
 download_url = url + '/archive/' + version + '.tar.gz'
 


### PR DESCRIPTION
* Create `utils.hash_key` function.
* Add `_hash_key` keyword argument to `cached` function. (resolves #7)
    + `_hash_key` defaults to `True`.
     + If `_hash_key` is set to `True`, keys generated from function calls are hashed and returned with fixed size of 65: first 32 symbols are md5 cache of [function qualified name](https://www.python.org/dev/peps/pep-3155/), symbol 33 is '_', and last 32 symbols are md5 cache of function arguments.